### PR TITLE
Fix STATUS_ACCESS_VIOLATION Bug on AMD

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,8 +423,8 @@ impl DXGIManager {
                             let stop = src.add(output_width);
                             // src = src.add(output_width);
                             while src != stop {
-                                src = src.add(1);
                                 dst.write(*src);
+                                src = src.add(1);
                                 dst = dst.add(1);
                             }
                         },


### PR DESCRIPTION
I noticed that on my NVidia GPU, this library worked fine, but switching to my AMD GPU caused it to throw a STATUS_ACCESS_VIOLATION. Looking further into the issue revealed that when this code was originally forked, there was a slight mistake in that the pointer was incremented before being de-referenced, causing it to miss the first pixel, and go out of bounds on the last pixel. 

Assuming this is unintended behavior and not purposeful in response to some underlying behavior on NVidia cards that I'm unaware of, I am shocked this worked in the first place on NVidia cards, and a little surprised no one noticed that every pixel was shifted 1 right.